### PR TITLE
feat: 支持 ZCode——走 ~/.agents/mcp.json 兼容路径，首次 install 自动建文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ npx huashu-chrome install
 
 **它认得出哪些 agent**，分三层：
 
-1. **已知表** —— `src/agents.json` 列了 20 个：Claude Code、Codex CLI、Cursor、
-   Gemini CLI、Windsurf、Cline、Roo Code、Claude Desktop，以及 WorkBuddy、CodeBuddy、
-   Kimi Code、通义灵码、MiniMax Mavis、Trae、豆包、千问 / Qwen Code、Qoder、
-   DeepSeek、iFlow、OpenClaw。加一个只要往数组里加一行，不用改代码 —— 欢迎 PR。
+1. **已知表** —— `src/agents.json` 列了 21 个：Claude Code、Codex CLI、Cursor、
+   Gemini CLI、Windsurf、Cline、Roo Code、Claude Desktop、ZCode，以及 WorkBuddy、
+   CodeBuddy、Kimi Code、通义灵码、MiniMax Mavis、Trae、豆包、千问 / Qwen Code、
+   Qoder、DeepSeek、iFlow、OpenClaw。加一个只要往数组里加一行，不用改代码 —— 欢迎 PR。
 2. **自动发现** —— 没列出来的也能认出来。`install` 会扫 home 下的点目录，
    凡是内容里有 `mcpServers` 的配置文件都算数。实测所有主流产品都守这个惯例
    （Codex 的 TOML 是唯一异类），所以下个月新冒出来的 agent 不用等更新也能配上。

--- a/src/agents.json
+++ b/src/agents.json
@@ -9,7 +9,12 @@
     "  client  传给 MCP server 的 --client，用于审计日志区分是谁在调",
     "  kind    json（{mcpServers:{}}，绝大多数）或 toml（[mcp_servers.x]，目前只有 Codex）",
     "  paths   候选路径，按顺序取第一个存在的。~ 是 home，$APPDATA 按平台展开",
-    "          （Windows→%APPDATA%，macOS→~/Library/Application Support，Linux→~/.config）"
+    "          （Windows→%APPDATA%，macOS→~/Library/Application Support，Linux→~/.config）",
+    "  ifDir   可选：用于判断 agent 是否真的装了。个别 agent 的 MCP 配置文件默认不存在",
+    "          （如 ZCode 走 ~/.agents/mcp.json 兼容路径，文件要首次 install 才建），",
+    "          光看路径存在与否会漏判，所以用这个标志目录（装了必在）来判断。",
+    "  create  可选（配合 ifDir）：paths 里的文件都不存在且 ifDir 存在时，install 会新建",
+    "          第一个路径的配置文件，而不是跳过。"
   ],
   "agents": [
     { "name": "Claude Code", "client": "claude-code", "kind": "json", "paths": ["~/.claude.json", "~/.claude/mcp.json"] },
@@ -20,6 +25,8 @@
     { "name": "Windsurf", "client": "windsurf", "kind": "json", "paths": ["~/.codeium/windsurf/mcp_config.json"] },
     { "name": "Cline (VS Code)", "client": "cline", "kind": "json", "paths": ["$APPDATA/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"] },
     { "name": "Roo Code", "client": "roo", "kind": "json", "paths": ["$APPDATA/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"] },
+
+    { "name": "ZCode", "client": "zcode", "kind": "json", "ifDir": "~/.zcode", "create": true, "paths": ["~/.agents/mcp.json"] },
 
     { "name": "WorkBuddy", "client": "workbuddy", "kind": "json", "paths": ["~/.workbuddy/.mcp.json"] },
     { "name": "CodeBuddy", "client": "codebuddy", "kind": "json", "paths": ["~/.codebuddy/mcp.json"] },

--- a/src/install.js
+++ b/src/install.js
@@ -37,10 +37,15 @@ const expand = (p) => p
   .split('/').join(path.sep);
 
 function knownAgents() {
-  return SPEC.agents.map((a) => ({
-    ...a,
-    file: a.paths.map(expand).find((f) => fs.existsSync(f)) || null,
-  }));
+  return SPEC.agents.map((a) => {
+    const file = a.paths.map(expand).find((f) => fs.existsSync(f)) || null;
+    // 个别 agent 的 MCP 配置文件默认不存在（首次 install 才会建）。
+    // 这时不能只看 paths 有没有命中——装没装要用一个「装了必在」的标志目录来判断
+    // （如 ZCode 的 ~/.zcode）。装了就把首个候选路径当配置文件，稍后新建。
+    const installed =
+      file || (a.create && a.ifDir && fs.existsSync(expand(a.ifDir))) || null;
+    return { ...a, file: installed ? file || expand(a.paths[0]) : null };
+  });
 }
 
 // 自动发现：在 home 的点目录里翻常见的 MCP 配置文件名。
@@ -179,10 +184,17 @@ export async function install({ yes = true, only = null } = {}) {
     let ok = 0;
     for (const t of plan) {
       try {
-        const backup = `${t.file}.bak-${Date.now()}`;
-        fs.copyFileSync(t.file, backup);
+        const isNew = !fs.existsSync(t.file);
+        if (isNew) {
+          // 配置文件原本不存在（ZCode 这类走兼容路径的 agent），第一次 install 才建。
+          // 没有「原文件」可备份，确保父目录在就直接写。
+          fs.mkdirSync(path.dirname(t.file), { recursive: true });
+        } else {
+          const backup = `${t.file}.bak-${Date.now()}`;
+          fs.copyFileSync(t.file, backup);
+          console.log(`  ✅ ${t.name}（原文件已备份为 ${path.basename(backup)}）`);
+        }
         t.kind === 'json' ? writeJson(t) : writeToml(t);
-        console.log(`  ✅ ${t.name}（原文件已备份为 ${path.basename(backup)}）`);
         ok++;
       } catch (e) {
         console.log(`  ❌ ${t.name}：${e.message}`);
@@ -210,17 +222,18 @@ function alreadyConfigured(t) {
   try {
     return fs.readFileSync(t.file, 'utf8').includes('huashu-chrome');
   } catch {
+    // 文件不存在（要新建的）或读不了，都算没配过
     return false;
   }
 }
 
 function writeJson(t) {
-  const raw = fs.readFileSync(t.file, 'utf8');
-  let cfg;
+  let cfg = {};
   try {
-    cfg = JSON.parse(raw);
+    // 配置文件可能不存在（首次 install 才建的 agent，如 ZCode）——从空对象开始
+    cfg = JSON.parse(fs.readFileSync(t.file, 'utf8'));
   } catch (e) {
-    throw new Error(`这个文件不是合法 JSON（${e.message}），不敢动它`);
+    if (e.code !== 'ENOENT') throw new Error(`这个文件不是合法 JSON（${e.message}），不敢动它`);
   }
   cfg.mcpServers = cfg.mcpServers || {};
   cfg.mcpServers['huashu-chrome'] = launcher(t.client);


### PR DESCRIPTION
## 背景

ZCode 是支持 MCP 的 agent，但它的 MCP 配置跟其它 agent 不一样：
- 主配置 `~/.zcode/cli/config.json` 用嵌套 `mcp.servers` 结构（与 `agents.json` 里所有 json 类 agent 的顶层 `mcpServers` 不同）
- 它也读兼容路径 `~/.agents/mcp.json`（顶层 `mcpServers`），**但仅当 zcode 主配置里没配任何 MCP server 时才生效**——对绝大多数用户（没手动配过 MCP）这正是默认状态
- 这个文件默认**不存在**，要首次 install 才建

现有 install 逻辑「只往已存在的配置文件里写」，会导致 ZCode 用户永远检测不到、被跳过。

## 改动

- **`src/agents.json`**：新增 ZCode 条目，`paths` 指向 `~/.agents/mcp.json`。给表加了两个可选字段：
  - `ifDir`：配置文件默认不存在时，用「装了必在」的标志目录（`~/.zcode`）判断 agent 是否真的装了
  - `create`：paths 未命中但 ifDir 存在时，install 新建首个路径的配置文件
- **`src/install.js`**：
  - `knownAgents()`：支持 ifDir/create 判定，把「装了但文件待建」的 agent 纳入
  - 写入循环：文件不存在时先 `mkdirSync` 父目录再写；没有原文件可备份，跳过备份提示
  - `writeJson()`：容错 `ENOENT`（文件不存在从空对象开始），非法 JSON 仍照旧报错保护
- **`README.md`**：已知表 20 → 21 个

## 兼容性

对已有配置文件的 agent（Claude Code / Codex / 等）行为完全不变：仍检测、仍先备份再写、仍打印备份文件名。新增的 `ifDir`/`create` 字段是可选字段，不带它们的既有条目不受影响。

## 验证

沙盒 `$HOME`（建 `~/.zcode`、不建 `~/.agents/mcp.json`）下：
- `install --dry-run` → 正确列出「ZCode 将写入 MCP 配置」
- `install` → 生成 `~/.agents/mcp.json`，内容为正确的 huashu-chrome server（`--client zcode`）
- 再跑一次 → 「已配置，跳过」（幂等）
- 同时含 `.claude.json` 时 → Claude Code 照旧备份+合并，ZCode 也一并写入

`npm test`：与上游基线完全一致（60 过 / 6 挂），6 个失败是依赖真实浏览器/桥的环境性失败，与本次改动无关。